### PR TITLE
fix: Content UI KIT

### DIFF
--- a/src/app/components/main-content/main-content.component.html
+++ b/src/app/components/main-content/main-content.component.html
@@ -137,13 +137,23 @@
   <div class="panel-horizontal-content">
     <div class="panel-horizontal">
       <div class="panel-body">
-        <h2 class="panel-title">UI KIT en Figma para diseñadores</h2>
+        <h2 class="panel-title">Librería en Figma para diseñadores</h2>
         <p class="panel-text">
-          El UI KIT de Obelisco contiene los componentes y guía de estilos para
-          construir prototipos de alta fidelidad y ayudar al equipo de gestión a
-          visualizar el producto final.
+          Obelisco cuenta con un conjunto de archivos que conforman la librería,
+          divididos en <strong>Core Components</strong> y
+          <strong> Foundations</strong>. Ambos archivos son parte del UI kit del
+          sistema de diseño, con el que puedes construir wireframes y prototipos
+          de alta fidelidad.
         </p>
-        <div class="panel-footer">
+        <a
+          class="external"
+          href="https://www.figma.com/@obeliscogcba"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Librería de Obelisco en Figma</a
+        >
+
+        <!-- <div class="panel-footer">
           <a
             class="btn btn-secondary btn-lg"
             href="../../../assets/UI KIT - Obelisco-V2.fig"
@@ -155,7 +165,7 @@
             >
             Descargar el UI KIT en Figma
           </a>
-        </div>
+        </div> -->
       </div>
     </div>
   </div>


### PR DESCRIPTION
Contenido de la parte de UI KIT según el figma:
[https://www.figma.com/design/FxdVYbJoHTutlmnc5Aeuvi/Web-Obelisco?node-id=3133-54052&m=dev](https://www.figma.com/design/FxdVYbJoHTutlmnc5Aeuvi/Web-Obelisco?node-id=3133-54052&m=dev)

Quedó así:
![image](https://github.com/user-attachments/assets/438f1bda-4ffa-47f8-882b-1f6e124eeafd)
